### PR TITLE
Dev

### DIFF
--- a/Texts/SimplifiedChineseVanilla.xml
+++ b/Texts/SimplifiedChineseVanilla.xml
@@ -56,7 +56,7 @@
     <loadingscreentip>在潜艇编辑器中，你可以将Wifi元件连接到无线电聊天模块，以构建语音控制系统。</loadingscreentip>
     <loadingscreentip>木星周围的辐射带得在木卫二表面建立永久定居点变得不现实，因此所有的木卫二前哨站都位于地表冰壳之下。</loadingscreentip>
     <loadingscreentip>木卫二的水下生态系统链条尚未完全明确，但人们相信食物链的基础是渺小的化学合成细菌。</loadingscreentip>
-    <loadingscreentip>木卫二联盟最初是两个最大的木卫二定居点与几个私人准军事组织之间的贸易合作协定，但后来逐渐发展为木卫二政府。</loadingscreentip>
+    <loadingscreentip>木卫二联盟最初是两个最大的木卫二定居点与几个私人准军事组织之间的贸易合作协定，但后来逐渐发展为木卫二的联合政府。</loadingscreentip>
     <loadingscreentip>有人计划在潜艇中派驻专业娱乐人员来缓解船员压力，不过这项计划很快被认定是失败的，并在人们的嘲讽声中终止了。</loadingscreentip>
     <loadingscreentip>大多数潜艇与船只都避免驶出隧道与木卫二冰层内部的裂缝——表层与内核之间的巨大深渊之中，潜藏着木卫二最巨大、最危险的“原生居民”。</loadingscreentip>
     <loadingscreentip>若放着它们不管，一群寄生植物群最终会聚合生长，成为一个能够控制它所居住的潜艇的高智能有机体——丘脑。</loadingscreentip>
@@ -264,7 +264,7 @@
     <PublishPopupInstall>安装中...</PublishPopupInstall>
     <PublishPopupCreateLocal>创建本地副本...</PublishPopupCreateLocal>
     <PublishPopupStaging>将项目复制到暂存文件夹...</PublishPopupStaging>
-    <PublishPopupSubmit>提交项目到工作室...</PublishPopupSubmit>
+    <PublishPopupSubmit>提交项目到创意工坊...</PublishPopupSubmit>
     <OpenLocalModInExplorer>本地模组\n点击在资源管理器中打开</OpenLocalModInExplorer>
     <ViewWorkshopModDetails>查看详情</ViewWorkshopModDetails>
     <EnableWorkshopMod>启用</EnableWorkshopMod>
@@ -1000,8 +1000,8 @@
     <playercredits>马克：[credits]</playercredits>
     <missioninfo>任务信息</missioninfo>
     <missionreward>奖励：[reward]</missionreward>
-    <missionrewardcargopercrate>奖励: [rewardpercrate] x [itemcount] (上限[maxitemcount]) = [totalreward]</missionrewardcargopercrate>
-    <missionrewardcargo>奖励: [totalreward] ([itemcount]箱 上限[maxitemcount])</missionrewardcargo>
+    <missionrewardcargopercrate>奖励: [rewardpercrate] x [itemcount] (最多运输[maxitemcount]) = [totalreward]</missionrewardcargopercrate>
+    <missionrewardcargo>奖励: [totalreward] ([itemcount]箱 最多运输[maxitemcount])</missionrewardcargo>
     <infobutton>信息</infobutton>
     <endround>结束巡回</endround>
     <enterlocation>进入 [locationname]</enterlocation>
@@ -1941,7 +1941,7 @@
     <entitydescription.railguncanistershellpellet>霰弹炮弹中填装的弹丸。</entitydescription.railguncanistershellpellet>
     <entityname.pulselaser>脉冲激光</entityname.pulselaser>
     <entitydescription.pulselaser>一种可作为炮塔装载的大型化学脉冲激光器，在充电后能发出威力强劲的激光束，对目标造成严重的灼伤。</entitydescription.pulselaser>
-    <entityname.pulselaserammobox>脉冲激光物资箱</entityname.pulselaserammobox>
+    <entityname.pulselaserammobox>脉冲激光弹药箱</entityname.pulselaserammobox>
     <entitydescription.pulselaserammobox>一个装好化学药剂和聚焦透镜的箱子，可以诱发强烈的能量爆发，可以视作脉冲激光的弹药。</entitydescription.pulselaserammobox>
     <entityname.pulselaserbolt>脉冲激光枪栓</entityname.pulselaserbolt>
     <entityname.pulselaserloader>脉冲激光装弹器</entityname.pulselaserloader>
@@ -2041,7 +2041,7 @@
     <entitydescription.coilgunammoboxpiercing>电磁枪弹药。具有穿甲效果。</entitydescription.coilgunammoboxpiercing>
     <entityname.chaingunammoboxphysicorium>刚素连射炮弹药箱</entityname.chaingunammoboxphysicorium>
     <entitydescription.chaingunammoboxphysicorium>极其沉重的，主体由刚素构成的连射炮弹药箱。这种弹药可以阻碍任何敌人的行动，甚至有可能将其击晕。</entitydescription.chaingunammoboxphysicorium>
-    <entityname.pulselaserammoboxtrilaser>三联脉冲激光物资箱</entityname.pulselaserammoboxtrilaser>
+    <entityname.pulselaserammoboxtrilaser>三联脉冲激光弹药箱</entityname.pulselaserammoboxtrilaser>
     <entitydescription.pulselaserammoboxtrilaser>一个装好化学药剂和聚焦透镜的箱子，可以诱发三束强力的激光，可以一次击中多个目标。</entitydescription.pulselaserammoboxtrilaser>
     <entityname.coilgunboltexplosive>爆破电磁枪矢</entityname.coilgunboltexplosive>
     <entitydescription.coilgunboltexplosive>电磁枪弹药。命中时爆炸。</entitydescription.coilgunboltexplosive>
@@ -2065,7 +2065,7 @@
     <entitydescription.alienspear>鱼叉枪的“弹药”，以异星原料制成。</entitydescription.alienspear>
     <entityname.explosivespear>爆炸鱼叉</entityname.explosivespear>
     <entitydescription.explosivespear>鱼叉枪的“弹药”。</entitydescription.explosivespear>
-    <entityname.harpoongun>鱼叉枪用的鱼叉枪。</entityname.harpoongun>
+    <entityname.harpoongun>鱼叉枪</entityname.harpoongun>
     <entitydescription.harpoongun>可发射鱼叉、爆炸鱼叉、刚素鱼叉。</entitydescription.harpoongun>
     <entityname.syringegun>注射器枪</entityname.syringegun>
     <entitydescription.syringegun>发射包含药物或毒液的注射器。</entitydescription.syringegun>
@@ -2624,7 +2624,7 @@
     <entitydescription.titanium>一种硬质金属。用于制作耐久的钛铝合金，以及部分军用设备。</entitydescription.titanium>
     <entityname.thorium>钍</entityname.thorium>
     <entitydescription.thorium>一种带有一定放射性的银色金属。可以精炼以制造耐用的燃料棒。</entitydescription.thorium>
-    <entityname.steel>钢筋</entityname.steel>
+    <entityname.steel>钢</entityname.steel>
     <entitydescription.steel>一种由碳和铁制成的高强度合金。用于燃料棒制造以及部分军用设备。</entitydescription.steel>
     <entityname.titaniumaluminiumalloy>钛铝合金</entityname.titaniumaluminiumalloy>
     <entitydescription.titaniumaluminiumalloy>一种高强度合金。用于制作耐久的潜水装备，以及高级军用设备。</entitydescription.titaniumaluminiumalloy>
@@ -3310,7 +3310,7 @@
     <reactorwarningcriticallowtemp>临界\n低温</reactorwarningcriticallowtemp>
     <reactorwarningcriticaloutput>临界\n输出</reactorwarningcriticaloutput>
     <reactorwarninglowtemp>温度过低</reactorwarninglowtemp>
-    <reactorwarningoverheating>炉芯过热</reactorwarningoverheating>
+    <reactorwarningoverheating>堆芯过热</reactorwarningoverheating>
     <reactorwarninglowoutput>输出过低</reactorwarninglowoutput>
     <reactorwarninghighoutput>输出过高</reactorwarninghighoutput>
     <reactorwarninglowfuel>燃料不足</reactorwarninglowfuel>
@@ -3950,7 +3950,7 @@
     <minorbleeding>轻微出血</minorbleeding>
     <bleeding>出血</bleeding>
     <heavybleeding>大出血</heavybleeding>
-    <catastrophicbleeding>血崩</catastrophicbleeding>
+    <catastrophicbleeding>血流如注</catastrophicbleeding>
     <noinjuries>无明显创伤</noinjuries>
     <minorinjuries>轻伤</minorinjuries>
     <injuries>受伤</injuries>
@@ -4885,7 +4885,7 @@
     <traitorgoalkeepalive>保护[speciesname]，[duration]秒。</traitorgoalkeepalive>
 
     <!-- MVP traitor mission text package -->
-    <mvptraitormissionstartinfotext>你脑袋里的一个声音吓了你一跳：“寄生虫教召唤你的服务！”</mvptraitormissionstartinfotext>
+    <mvptraitormissionstartinfotext>你脑袋里的一个声音吓了你一跳：“画皮神教需要你的服务！”</mvptraitormissionstartinfotext>
     <mvptraitorobjectivestartmessage1>你的脑海中涌出了一个想法，尽管平庸无比，但还是占据了你的心志：\n[traitorgoalinfos]</mvptraitorobjectivestartmessage1>
     <mvp_goalinfotext_1>寻找储藏柜 - 给你的特别消息就藏在一个备用氧气罐下面。</mvp_goalinfotext_1>
     <mvpobjectivesuccessmessage1>不知怎么，氧气罐下面真的藏着一张肮脏的纸片。上面涂抹着原始的字样，但你本能的理解了上面的内容。</mvpobjectivesuccessmessage1>
@@ -5790,7 +5790,7 @@
     <upgradename.increasewallhealth>强化船壳</upgradename.increasewallhealth>
     <upgradedescription.increasewallhealth>提升潜艇外壳强度，使潜艇外壳更加牢靠，使其能够抵御更深层海域的水压。</upgradedescription.increasewallhealth>
     <upgradename.increasedeteriorationdelay>耐久性增强</upgradename.increasedeteriorationdelay>
-    <upgradedescription.increasedeteriorationdelay>船内设备使用更久后才会开始恶化</upgradedescription.increasedeteriorationdelay>
+    <upgradedescription.increasedeteriorationdelay>船内设备使用更久后才会开始老化。</upgradedescription.increasedeteriorationdelay>
     <upgradename.decreasedeteriorationspeed>冗余系统增强</upgradename.decreasedeteriorationspeed>
     <upgradedescription.decreasedeteriorationspeed>船内设备老化的速度有所减缓</upgradedescription.decreasedeteriorationspeed>
     <upgradename.decreaselowskillfixduration>模组化修复</upgradename.decreaselowskillfixduration>
@@ -5807,8 +5807,8 @@
     <upgradedescription.decreasedeconstructiontime>减少解构物品所需的时间，但略微提高能量使用。</upgradedescription.decreasedeconstructiontime>
     <upgradename.turretdecreasepowerconsumption>能效提升</upgradename.turretdecreasepowerconsumption>
     <upgradedescription.turretdecreasepowerconsumption>降低功耗。</upgradedescription.turretdecreasepowerconsumption>
-    <upgradename.turretincreaserotationlowskill>快速装弹</upgradename.turretincreaserotationlowskill>
-    <upgradedescription.turretincreaserotationlowskill>减少船员技能等级不足时装弹所需时间</upgradedescription.turretincreaserotationlowskill>
+    <upgradename.turretincreaserotationlowskill>快速转向</upgradename.turretincreaserotationlowskill>
+    <upgradedescription.turretincreaserotationlowskill>为技能不熟练的船员提升炮塔转向速度。</upgradedescription.turretincreaserotationlowskill>
     <upgradename.turretincreaseoffsetonselected>潜望镜增强</upgradename.turretincreaseoffsetonselected>
     <upgradedescription.turretincreaseoffsetonselected>提升所有武器的观察范围。</upgradedescription.turretincreaseoffsetonselected>
     <upgradename.increaseoxygengeneration>高效制氧</upgradename.increaseoxygengeneration>
@@ -5816,9 +5816,9 @@
     <upgradename.increasereactoroutput>高效反应堆</upgradename.increasereactoroutput>
     <upgradedescription.increasereactoroutput>提升反应堆输出功率。</upgradedescription.increasereactoroutput>
     <upgradename.decreasefuelconsumption>改良冷却棒</upgradename.decreasefuelconsumption>
-    <upgradedescription.decreasefuelconsumption>降低油耗率。提高反应堆在熔毁前能在临界温度支持的时间。</upgradedescription.decreasefuelconsumption>
+    <upgradedescription.decreasefuelconsumption>降低燃料棒消耗速度。提高反应堆处在临界温度而不熔毁的时间。</upgradedescription.decreasefuelconsumption>
     <upgradename.increasemeltdowndelay>耐热反应堆</upgradename.increasemeltdowndelay>
-    <upgradedescription.increasemeltdowndelay>提升反应堆在熔毁前维持临界温度的时间。</upgradedescription.increasemeltdowndelay>
+    <upgradedescription.increasemeltdowndelay>提高反应堆处在临界温度而不熔毁的时间。</upgradedescription.increasemeltdowndelay>
     <upgradename.increasemaxpumpflow>高效水泵</upgradename.increasemaxpumpflow>
     <upgradedescription.increasemaxpumpflow>提升水泵的抽出泵入效率。降低水泵能量消耗。</upgradedescription.increasemaxpumpflow>
     <upgradename.increaseenginemaxforce>增强引擎</upgradename.increaseenginemaxforce>
@@ -6148,7 +6148,7 @@
     <qualitystattypenames.repairspeed>修复速度</qualitystattypenames.repairspeed>
     <qualitystattypenames.repairtoolstructurerepairmultiplier>船体修复速度</qualitystattypenames.repairtoolstructurerepairmultiplier>
     <qualitystattypenames.repairtoolstructuredamagemultiplier>船体伤害</qualitystattypenames.repairtoolstructuredamagemultiplier>
-    <qualitystattypenames.repairtooldeattachtimemultiplier>分离速度减少</qualitystattypenames.repairtooldeattachtimemultiplier>
+    <qualitystattypenames.repairtooldeattachtimemultiplier>分离时间减少</qualitystattypenames.repairtooldeattachtimemultiplier>
     <qualitystattypenames.attackmultiplier>攻击力</qualitystattypenames.attackmultiplier>
     <qualitystattypenames.attackspeedmultiplier>攻击速度</qualitystattypenames.attackspeedmultiplier>
     <qualitystattypenames.forcedoorsopenspeedmultiplier>撬门速度</qualitystattypenames.forcedoorsopenspeedmultiplier>
@@ -6325,7 +6325,7 @@
     <talentdescription.tinker.fabricatoranddeconstructor>你可以超频加工台或解构仪，使其的运行速度提高[speedincrease]%。</talentdescription.tinker.fabricatoranddeconstructor>
     <talentdescription.honkinggivesskillgain>有了小丑之力后，你可以通过鸣喇叭让附近的友军在短时间内获得[skillgainincrease]%的技能加成。</talentdescription.honkinggivesskillgain>
     <talentdescription.honkinghealscharacters>有了小丑之力后，你可以通过鸣喇叭让附近的友军缓慢恢复生命。</talentdescription.honkinghealscharacters>
-    <talentdescription.standanddeliver>每当你完成任一任务，都会获得一本《水手指南》。\n当你使用《水手指南》，附近所有船员提升其所有技能[skillamount]点。</talentdescription.standanddeliver>
+    <talentdescription.standanddeliver>每当你完成任一任务，都会获得一本《水手指南》。\n当你使用《水手指南》，离你最近的船员提升其所有技能[skillamount]点。</talentdescription.standanddeliver>
     <talentdescription.letitdrainreminder>你最多只能在你的潜艇上安装[itemcount]个该物品。</talentdescription.letitdrainreminder>
     <talentdescription.cannedheat>每当你演奏手风琴时，离你最近的友军将每秒获得[allyexperienceamount]经验。当友军获得经验时，你会获得[experienceamount]经验。</talentdescription.cannedheat>
     <talentdescription.nuclearoption>当你制造燃料棒时，获得三倍产出。</talentdescription.nuclearoption>

--- a/Texts/SimplifiedChineseVanillaEditorTexts.xml
+++ b/Texts/SimplifiedChineseVanillaEditorTexts.xml
@@ -7,8 +7,8 @@
     <!-- Submarine Editor -->
     <items>物品</items>
     <structures>结构</structures>
-    <totalhullvolume>总的艇体空间</totalhullvolume>
-    <selectedhullvolume>选定的艇体空间</selectedhullvolume>
+    <totalhullvolume>总的船体空间</totalhullvolume>
+    <selectedhullvolume>选定的船体空间</selectedhullvolume>
     <optimalballastlevel>压载舱悬浮最佳水位[value]</optimalballastlevel>
     <saveitemassembly>保存为物品组件</saveitemassembly>
     <insufficientballast>压载舱体积空间不足以控制浮潜</insufficientballast>
@@ -34,8 +34,8 @@
     <showwaypoints>路径点</showwaypoints>
     <showspawnpoints>生成点</showspawnpoints>
     <showlinks>连接</showlinks>
-    <showhulls>艇体</showhulls>
-    <showgaps>分隔点</showgaps>
+    <showhulls>船体</showhulls>
+    <showgaps>间隙</showgaps>
     <previouslyusedlabel>上次使用</previouslyusedlabel>
     <subnamemissingwarning>保存前请命名你的潜水艇。</subnamemissingwarning>
     <subnameillegalcharswarning>文件名包含非法字符([illegalchar])</subnameillegalcharswarning>
@@ -51,7 +51,7 @@
     <itemassemblynamemissingwarning>保存前请给物品组件命名.</itemassemblynamemissingwarning>
     <itemassemblyfileexistswarning>存在相同名称的物品组件。你是要覆盖掉这个物品组件吗?</itemassemblyfileexistswarning>
     <itemassemblynameillegalcharswarning>文件名包含非法字符([illegalchar])</itemassemblynameillegalcharswarning>
-    <nohullswarning>未在该潜艇找到艇体结构. 艇体结构是潜艇中作为识别舱室的'边界'，只有存在舱室的情况下，潜艇中才会视为有空气和水的流动。</nohullswarning>
+    <nohullswarning>未在该潜艇找到船体结构. 船体结构是潜艇中作为识别舱室的'边界'，只有存在舱室的情况下，潜艇中才会视为有空气和水的流动。</nohullswarning>
     <disconnectedventswarning>潜水艇安装的通风口未连接到制氧机上。选定通风口，按住空格并单击制氧机来进行连接。</disconnectedventswarning>
     <disconnectedturretswarning>潜水艇安装的[itemname]未连接到装弹器. 选定该物品，按住空格并单击装弹器来进行连接</disconnectedturretswarning>
     <nowaypointswarning>潜艇上未找到路径点. 没有路径点将导致 AI 船员无法行动。</nowaypointswarning>
@@ -61,7 +61,7 @@
     <adjustedlightsnotification>潜艇的光影效果已调整。有多个光源的区域可能还是会显得很亮，需要手动降低灯光的范围或亮度。 你也可以使用控制台命令'multiplylights'一次调整所有灯的亮度. 例如, 'multiplylights 1,1,1,0.5' 会降低亮度 50%.</adjustedlightsnotification>
     <noballasttagswarning>你应该在压载舱水泵上添加标签“压载”，以允许 AI 船员识别哪些泵用于控制潜艇的浮力。</noballasttagswarning>
     <insufficientfreeconnectionswarning>该模块包含一个连接了[doorcount]个门的接线盒，但只有[freeconnectioncount]个的空闲接线位置。这可能会导致前哨站的供电不正确。</insufficientfreeconnectionswarning>
-    <nohullnameswarning>没有给任何艇体（舱室）命名，将使用自动生成的名称。角色在报告如舱室进水等事件时将会使用自动生成的名称。</nohullnameswarning>
+    <nohullnameswarning>没有给任何船体（舱室）命名，将使用自动生成的名称。角色在报告如舱室进水等事件时将会使用自动生成的名称。</nohullnameswarning>
     <deletingcontainerwithitems>一个装有物品的货柜已经移除, 同时也移除包含的物品?\n\n包含物品:\n\n</deletingcontainerwithitems>
     <hideinmenus>在菜单隐藏</hideinmenus>
     <manuallyoutfitted>手动装配物资</manuallyoutfitted>
@@ -73,7 +73,7 @@
     <mirrorentityxtooltip>水平方向翻转物体。也可以使用快捷键Ctrl + N.</mirrorentityxtooltip>
     <mirrorentityy>竖直翻转</mirrorentityy>
     <mirrorentityytooltip>竖直向翻转物体。也可以使用快捷键Ctrl + M.</mirrorentityytooltip>
-    <nonlinkedgapswarning>潜艇上有一些未与艇体相接的分隔点。分隔点应始终至少与一个艇体（如船员通过该分隔点到达潜艇外部），如要分隔出两个舱室，则分隔点需要在两个艇体之间。</nonlinkedgapswarning>
+    <nonlinkedgapswarning>潜艇上有一些未与船体相接的间隙。间隙应始终至少与一个船体（如船员通过该间隙到达潜艇外部），如要分隔出两个舱室，则需要在两个船体之间存在间隙。</nonlinkedgapswarning>
     <cannoteditvanillasubs>无法编辑原版内容包中定义的潜艇！</cannoteditvanillasubs>
     <subeditor.structurecountwarning>潜艇中的结构数量非常多，这可能会导致性能相关的问题。可考虑减少结构的数量。</subeditor.structurecountwarning>
     <subeditor.structurecounterror>潜艇结构数量超出上限 (>[max]), 将导致性能问题。 请减少结构的数量。</subeditor.structurecounterror>
@@ -425,7 +425,7 @@
     <sp.minimap.requirewaterdetectors.description>机器是否需要安装水位传感器才能显示舱室内的水位信息。</sp.minimap.requirewaterdetectors.description>
     <sp.minimap.requireoxygendetectors.name>需要氧含量传感器</sp.minimap.requireoxygendetectors.name>
     <sp.minimap.requireoxygendetectors.description>机器是否需要安装氧含量传感器才能显示舱室内的氧气含量。</sp.minimap.requireoxygendetectors.description>
-    <sp.minimap.showhullintegrity.name>显示艇体完整度</sp.minimap.showhullintegrity.name>
+    <sp.minimap.showhullintegrity.name>显示船体完整度</sp.minimap.showhullintegrity.name>
     <sp.minimap.showhullintegrity.description>机器是否显示舱内墙体受损的位置。</sp.minimap.showhullintegrity.description>
     <sp.reactor.maxpoweroutput.name>最高电力输出</sp.reactor.maxpoweroutput.name>
     <sp.reactor.maxpoweroutput.description>反应堆满负荷运行时产生的电力（kW）。</sp.reactor.maxpoweroutput.description>
@@ -595,10 +595,10 @@
     <sp.vulnerabletoemp.description>电磁脉冲是否会损坏该物品。</sp.vulnerabletoemp.description>
 
     <!-- Structure -->
-    <entityname.hull>艇体</entityname.hull>
-    <entitydescription.hull>艇体决定了那些区域是属于'潜艇内'。 一般每个封闭的舱室都应该存在艇体。</entitydescription.hull>
-    <entityname.gap>分隔点</entityname.gap>
-    <entitydescription.gap>分隔点能让水和空气在两个艇体间流动。</entitydescription.gap>
+    <entityname.hull>船体</entityname.hull>
+    <entitydescription.hull>船体决定了那些区域是属于'潜艇内部'，分隔空间。 一般每个封闭的舱室都应该存在船体。</entitydescription.hull>
+    <entityname.gap>间隙</entityname.gap>
+    <entitydescription.gap>间隙能让水和空气在两个船体间流动。</entitydescription.gap>
     <entityname.waypoint>路径点</entityname.waypoint>
     <entitydescription.waypoint>用于AI船员在潜艇内行动。</entitydescription.waypoint>
     <entityname.spawnpoint>生成点</entityname.spawnpoint>


### PR DESCRIPTION
界面
1. 材料“钢筋”修正为“钢” - 行2627
2. “炉芯过热” 修正为 “堆芯过热” 3313
3. 健康状态“血崩”润色为“血流如注” 3953
4. “寄生虫教”修正为“画皮神教” 4888
5. “恶化” -> ”老化“ 5793
6. 潜艇升级选项翻译错误修正 “快速装弹” -> “快速转向” 和其描述“减少船员技能等级不足时装弹所需时间”修正为“为技能不熟练的船员提升炮塔转向速度。” 5810-5811
7. 5819 润色“降低燃料棒消耗速度。提高反应堆处在临界温度而不熔毁的时间。”
8. 6151 润色 “分离时间减少”
9. 助手技能“辗转相传”描述从“附近所有船员提升其所有技能”的错误修正为“离你最近的船员提升其所有技能”

---
编辑器
1. “艇体”翻译还原为“船体”
2. “分隔点”（Gap） 重新翻译为“间隙” - 参考了steam指南《【翻译】官方潜艇制作编辑器手册 Official submarine builder’s manual》